### PR TITLE
Fixed formatting in Manual.md

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -40,7 +40,8 @@ Note that each line begins with a two-character line code, which indicates the t
 
 A sample entry is shown below:
 
-```ID   HLA00001; SV 1; standard; DNA; HUM; 3503 BP.
+```
+ID   HLA00001; SV 1; standard; DNA; HUM; 3503 BP.
 XX
 AC   HLA00001;
 XX


### PR DESCRIPTION
The newline symbol is missing after the opening three backticks, so the ID-line (the first line in the example) is not displayed properly on the website.